### PR TITLE
feat: unificar tipos de recordatorio y categorías en un solo sistema

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 import CategoryModal from './components/CategoryModal.vue';
 import CategoryButton from './components/CategoryButton.vue';
 import { useReminders } from './composables/useReminders';
@@ -13,6 +13,7 @@ import QuickStatsMobile from './components/QuickStatsMobile.vue';
 import EmptyState from './components/EmptyState.vue';
 import OptionsMenu from './components/OptionsMenu.vue';
 import { NotificationManager } from './utils/notifications';
+import { Category } from './models/Category.js';
 import logo from './assets/logo.png'
 
 const {
@@ -134,6 +135,11 @@ const getCurrentViewLabel = computed(() => {
 
 const currentReminders = computed(() => {
    return quickStatsFilteredReminders.value;
+});
+
+// Inicializar categorías por defecto al montar la aplicación
+onMounted(() => {
+   Category.initializeDefaults();
 });
 
 const handleClearCompleted = () => {

--- a/src/components/AddReminderModal.vue
+++ b/src/components/AddReminderModal.vue
@@ -62,26 +62,30 @@
 								</div>
 							</div>
 
-							<!-- Type -->
-							<div>
-								<label class="block text-sm font-medium text-gray-700 mb-2">
-									{{ UI_LABELS.FORM.TYPE_LABEL }}
-								</label>
-								<div class="grid grid-cols-2 gap-3">
-									<button v-for="type in REMINDER_TYPES" :key="type.value" type="button"
-										@click="formData.type = type.value" :class="[
-											'flex items-center gap-3 p-3 rounded-xl border-2 transition-all duration-200',
-											formData.type === type.value
-												? 'border-primary-500 bg-primary-50 text-primary-700'
-												: 'border-gray-200 hover:border-gray-300 text-gray-600'
-										]">
-										<span class="text-lg">{{ type.icon }}</span>
-										<span class="font-medium text-sm">{{ type.label }}</span>
-									</button>
+						<!-- Category -->
+						<div>
+							<label class="block text-sm font-medium text-gray-700 mb-2">
+								{{ UI_LABELS.FORM.TYPE_LABEL }}
+							</label>
+							<div class="relative">
+								<select v-model="formData.category" 
+									class="input-field appearance-none cursor-pointer pr-10 bg-white"
+									required>
+									<option v-for="category in availableCategories" :key="category.id" :value="category.name">
+										{{ category.icon }} {{ category.name }}
+									</option>
+								</select>
+								<!-- Custom dropdown arrow -->
+								<div class="absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none">
+									<svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+									</svg>
 								</div>
 							</div>
-
-							<!-- Date and Time -->
+							<p class="mt-1 text-xs text-gray-500">
+								Selecciona la categoría que mejor se adapte a tu actividad
+							</p>
+						</div>							<!-- Date and Time -->
 							<div>
 								<label class="block text-sm font-medium text-gray-700 mb-2">
 									{{ UI_LABELS.FORM.DATE_LABEL }}
@@ -147,16 +151,16 @@
 </template>
 
 <script setup>
-import { ref, computed, watch } from 'vue';
+import { ref, computed, watch, onMounted } from 'vue';
 import { getUrgencyLevel } from '../utils/dateHelpers';
+import { Category } from '../models/Category.js';
 import { 
-   REMINDER_TYPES, 
-   DEFAULT_REMINDER_TYPE,
    VALIDATION_RULES,
    VALIDATION_MESSAGES,
    URGENCY_INFO_MAP,
    UI_LABELS,
-   Z_INDEX
+   Z_INDEX,
+   DEFAULT_REMINDER_CATEGORY
 } from '../config/constants';
 
 const props = defineProps({
@@ -172,10 +176,13 @@ const props = defineProps({
 
 const emit = defineEmits(['close', 'submit']);
 
+// Cargar categorías disponibles
+const availableCategories = ref([]);
+
 const formData = ref({
 	title: '',
 	description: '',
-	type: DEFAULT_REMINDER_TYPE,
+	category: DEFAULT_REMINDER_CATEGORY,
 	date: ''
 });
 
@@ -331,7 +338,7 @@ const resetForm = () => {
 	formData.value = {
 		title: '',
 		description: '',
-		type: DEFAULT_REMINDER_TYPE,
+		category: DEFAULT_REMINDER_CATEGORY,
 		date: ''
 	};
 	errors.value = {
@@ -341,13 +348,23 @@ const resetForm = () => {
 	};
 };
 
+// Cargar categorías al montar el componente
+const loadCategories = () => {
+	Category.initializeDefaults(); // Asegurarse de que existan las categorías por defecto
+	availableCategories.value = Category.all();
+};
+
+onMounted(() => {
+	loadCategories();
+});
+
 // Watch for edit mode
 watch(() => props.editReminder, (newVal) => {
 	if (newVal) {
 		formData.value = {
 			title: newVal.title || '',
 			description: newVal.description || '',
-			type: newVal.type || DEFAULT_REMINDER_TYPE,
+			category: newVal.category || DEFAULT_REMINDER_CATEGORY,
 			date: newVal.date ? new Date(newVal.date).toISOString().slice(0, 16) : ''
 		};
 	} else {

--- a/src/components/FilterBar.vue
+++ b/src/components/FilterBar.vue
@@ -76,7 +76,8 @@
 </template>
 
 <script setup>
-import { computed } from 'vue';
+import { computed, ref, onMounted } from 'vue';
+import { Category } from '../models/Category.js';
 
 const props = defineProps({
    searchQuery: {
@@ -99,13 +100,28 @@ const emit = defineEmits([
    'update:selectedFilter'
 ]);
 
-const categories = [
-   { value: 'all', label: 'Todos', icon: '📋' },
-   { value: 'exam', label: 'Exámenes', icon: '📚' },
-   { value: 'task', label: 'Tareas', icon: '📝' },
-   { value: 'presentation', label: 'Presentaciones', icon: '🎤' },
-   { value: 'meeting', label: 'Reuniones', icon: '👥' }
-];
+// Categorías dinámicas
+const categories = ref([]);
+
+const loadCategories = () => {
+   Category.initializeDefaults(); // Asegurar que existan
+   const allCategories = Category.all();
+   
+   // Crear array con "Todos" primero y luego las categorías reales
+   categories.value = [
+      { value: 'all', label: 'Todos', icon: '�' },
+      ...allCategories.map(cat => ({
+         value: cat.name, // Usar nombre en lugar de slug
+         label: cat.name,
+         icon: cat.icon
+      }))
+   ];
+};
+
+// Cargar categorías al montar
+onMounted(() => {
+   loadCategories();
+});
 
 const dateFilters = [
    { value: 'all', label: 'Todas las fechas' },
@@ -121,13 +137,13 @@ const hasActiveFilters = computed(() => {
 });
 
 const getCategoryLabel = (value) => {
-   const category = categories.find(c => c.value === value);
+   const category = categories.value.find(c => c.value === value);
    return category ? `${category.icon} ${category.label}` : '';
 };
 
 const getFilterLabel = (value) => {
    const filter = dateFilters.find(f => f.value === value);
-   return filter ? filter : '';
+   return filter ? filter.label : '';
 };
 
 const clearSearch = () => {

--- a/src/components/ReminderCard.vue
+++ b/src/components/ReminderCard.vue
@@ -128,16 +128,19 @@ const emit = defineEmits(['toggle', 'edit', 'delete']);
 const showCompletionAnimation = ref(false);
 const completed = computed(() => props.reminder.completed);
 
-const categoryIcons = {
-   exam: '📚',
-   task: '📝',
-   presentation: '🎤',
-   meeting: '👥',
-   other: '📌'
-};
-
 const categoryIcon = computed(() => {
-   return categoryIcons[props.reminder.type] || categoryIcons.other;
+   // Buscar la categoría por nombre para obtener su icono
+   if (props.reminder.category) {
+      // Para mantener compatibilidad, mapear nombres conocidos a iconos
+      const iconMap = {
+         'Examen': '📚',
+         'Tarea': '📝',
+         'Presentación': '🎤',
+         'Reunión': '👥'
+      };
+      return iconMap[props.reminder.category] || '📌';
+   }
+   return '📌';
 });
 
 const formattedDate = computed(() => {
@@ -196,6 +199,7 @@ watch(completed, (newVal, oldVal) => {
 .line-clamp-2 {
    display: -webkit-box;
    -webkit-line-clamp: 2;
+   line-clamp: 2;
    -webkit-box-orient: vertical;
    overflow: hidden;
 }

--- a/src/composables/useCategories.js
+++ b/src/composables/useCategories.js
@@ -1,26 +1,58 @@
 import { ref } from 'vue';
-import { categoryStorage } from '../utils/localStorage';
+import { Category } from '../models/Category.js';
 
 export function useCategories() {
   const categories = ref([]);
 
   const loadCategories = () => {
-    categories.value = categoryStorage.getCategories();
+    // Asegurar que existan las categorías por defecto
+    Category.initializeDefaults();
+    // Cargar todas las categorías del modelo
+    categories.value = Category.all().map(cat => ({
+      value: cat.name.toLowerCase().replace(/\s+/g, '-'), // Para compatibilidad
+      label: cat.name,
+      icon: cat.icon,
+      id: cat.id,
+      name: cat.name,
+      color: cat.color,
+      description: cat.description
+    }));
   };
 
-  const addCategory = (category) => {
-    categoryStorage.addCategory(category);
+  const addCategory = (categoryData) => {
+    // Crear nueva categoría usando el modelo Category
+    const category = new Category({
+      name: categoryData.label,
+      icon: categoryData.icon,
+      color: '#95a5a6', // Color por defecto
+      description: `Categoría ${categoryData.label}`
+    });
+    category.save();
     loadCategories();
   };
 
   const updateCategory = (value, updates) => {
-    categoryStorage.updateCategory(value, updates);
-    loadCategories();
+    // Buscar la categoría por value (slug) y actualizarla
+    const category = Category.all().find(cat => 
+      cat.name.toLowerCase().replace(/\s+/g, '-') === value
+    );
+    if (category) {
+      category.name = updates.label;
+      category.icon = updates.icon;
+      category.save();
+      loadCategories();
+    }
   };
 
   const deleteCategory = (value) => {
-    categoryStorage.deleteCategory(value);
-    loadCategories();
+    // Buscar y eliminar la categoría
+    const category = Category.all().find(cat => 
+      cat.name.toLowerCase().replace(/\s+/g, '-') === value
+    );
+    if (category) {
+      category.delete();
+      loadCategories();
+    }
   };
 
   // Inicializar

--- a/src/composables/useReminderActions.js
+++ b/src/composables/useReminderActions.js
@@ -5,7 +5,45 @@ export function useReminderActions() {
    const reminders = ref([]);
 
    const loadReminders = () => {
+      // Migrar recordatorios del campo 'type' a 'category' si es necesario
+      migrateReminderTypes();
       reminders.value = storage.getReminders();
+   };
+
+   const migrateReminderTypes = () => {
+      try {
+         const storedReminders = storage.getReminders();
+         let needsMigration = false;
+         
+         const migratedReminders = storedReminders.map(reminder => {
+            // Si el recordatorio tiene 'type' pero no 'category', migrar
+            if (reminder.type && !reminder.category) {
+               needsMigration = true;
+               // Mapear tipos antiguos a nombres de categorías
+               const typeToCategory = {
+                  'exam': 'Exámenes',
+                  'task': 'Tareas',
+                  'presentation': 'Presentaciones',
+                  'meeting': 'Reuniones'
+               };
+               
+               return {
+                  ...reminder,
+                  category: typeToCategory[reminder.type] || reminder.type,
+                  // Mantener type por compatibilidad temporal
+                  type: reminder.type
+               };
+            }
+            return reminder;
+         });
+         
+         if (needsMigration) {
+            storage.saveReminders(migratedReminders);
+            console.log('Migrados recordatorios de type a category');
+         }
+      } catch (error) {
+         console.warn('Error en migración de recordatorios:', error);
+      }
    };
 
    const addReminder = (reminderData) => {

--- a/src/composables/useReminderFilters.js
+++ b/src/composables/useReminderFilters.js
@@ -21,7 +21,7 @@ export function useReminderFilters(reminders) {
 
       // Filtrar por categoría
       if (selectedCategory.value !== 'all') {
-         filtered = filtered.filter(r => r.type === selectedCategory.value);
+         filtered = filtered.filter(r => r.category === selectedCategory.value);
       }
 
       // Filtrar por rango de fechas

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -75,33 +75,17 @@ export const RELATIVE_DATE_LABELS = {
 };
 
 // ===========================
-// TIPOS DE RECORDATORIO
+// TIPOS DE RECORDATORIO (CATEGORÍAS)
 // ===========================
 
-export const REMINDER_TYPES = [
-   {
-      value: 'exam',
-      label: 'Examen',
-      icon: '📚'
-   },
-   {
-      value: 'task',
-      label: 'Tarea',
-      icon: '📝'
-   },
-   {
-      value: 'presentation',
-      label: 'Presentación',
-      icon: '🎤'
-   },
-   {
-      value: 'meeting',
-      label: 'Reunión',
-      icon: '👥'
-   }
-];
+// Los tipos ahora se obtienen dinámicamente del modelo Category
+// Para mantener compatibilidad, se define una función helper
+export const getReminderTypes = () => {
+   // Esta función será importada donde se necesite y llamará a Category.all()
+   return []  // Temporal - se implementará en los componentes
+}
 
-export const DEFAULT_REMINDER_TYPE = 'task';
+export const DEFAULT_REMINDER_CATEGORY = 'Tarea';
 
 // ===========================
 // VALIDACIÓN DE FORMULARIOS
@@ -196,7 +180,7 @@ export const UI_LABELS = {
       DESCRIPTION_PLACEHOLDER: 'Añade detalles importantes...',
       DESCRIPTION_HELPER: `Máximo ${VALIDATION_RULES.DESCRIPTION.MAX_LENGTH} caracteres`,
 
-      TYPE_LABEL: 'Tipo de recordatorio',
+      TYPE_LABEL: 'Categoría',
 
       DATE_LABEL: 'Fecha y hora *',
       DATE_HELPER: `Debe ser al menos ${VALIDATION_RULES.DATE.MIN_FUTURE_MINUTES} minuto en el futuro`,

--- a/src/models/Category.js
+++ b/src/models/Category.js
@@ -160,6 +160,82 @@ export class Category extends BaseModel {
     })
   }
 
+  /**
+   * Inicializa las categorías por defecto si no existen
+   * @returns {Array<Category>} - Array de categorías por defecto
+   */
+  static initializeDefaults() {
+    const existing = this.all()
+    
+    // Si ya hay categorías, migrar las del sistema antiguo si es necesario
+    if (existing.length === 0) {
+      // Intentar migrar categorías del sistema antiguo (localStorage)
+      this._migrateFromOldSystem()
+    }
+    
+    // Si después de la migración aún no hay categorías, crear las por defecto
+    const currentCategories = this.all()
+    if (currentCategories.length === 0) {
+      const defaultCategories = [
+        {
+          name: 'Examen',
+          icon: '📚',
+          color: '#3498db',
+          description: 'Exámenes y evaluaciones académicas'
+        },
+        {
+          name: 'Tarea',
+          icon: '📝',
+          color: '#2ecc71',
+          description: 'Tareas y asignaciones'
+        },
+        {
+          name: 'Presentación',
+          icon: '🎤',
+          color: '#e74c3c',
+          description: 'Presentaciones y exposiciones'
+        },
+        {
+          name: 'Reunión',
+          icon: '👥',
+          color: '#f39c12',
+          description: 'Reuniones y citas académicas'
+        }
+      ]
+      
+      return this.bulkCreate(defaultCategories)
+    }
+    return currentCategories
+  }
+
+  /**
+   * Migra categorías del sistema antiguo al nuevo modelo
+   * @private
+   */
+  static _migrateFromOldSystem() {
+    try {
+      const oldCategories = JSON.parse(localStorage.getItem('categories') || '[]')
+      if (oldCategories.length > 0) {
+        // Convertir categorías antiguas al nuevo formato
+        const newCategories = oldCategories
+          .filter(cat => cat.value !== 'all') // Excluir "Todos"
+          .map(cat => ({
+            name: cat.label,
+            icon: cat.icon,
+            color: '#95a5a6', // Color por defecto
+            description: `Categoría ${cat.label}`
+          }))
+        
+        if (newCategories.length > 0) {
+          this.bulkCreate(newCategories)
+          console.log(`Migradas ${newCategories.length} categorías del sistema antiguo`)
+        }
+      }
+    } catch (error) {
+      console.warn('Error al migrar categorías del sistema antiguo:', error)
+    }
+  }
+
   // Métodos privados
 
   /**

--- a/src/utils/exportHelpers.js
+++ b/src/utils/exportHelpers.js
@@ -39,12 +39,12 @@ export const exportToJSON = (reminders) => {
  * ]); // Descarga archivo: edureminder-export-2024-01-01.csv
  */
 export const exportToCSV = (reminders) => {
-   const headers = ['ID', 'Título', 'Descripción', 'Tipo', 'Fecha', 'Completado', 'Fecha de creación'];
+   const headers = ['ID', 'Título', 'Descripción', 'Categoría', 'Fecha', 'Completado', 'Fecha de creación'];
    const rows = reminders.map(reminder => [
       reminder.id,
       `"${reminder.title}"`,
       `"${reminder.description || ''}"`,
-      reminder.type,
+      reminder.category,
       reminder.date,
       reminder.completed ? 'Sí' : 'No',
       reminder.createdAt


### PR DESCRIPTION
## ¿Qué cambios hice?
Unifiqué el sistema de tipos de recordatorio y categorías,  en el modal nuevo recordatorio se agrego selector.

- Actualicé el modal de recordatorios (AddReminderModal.vue) para mostrar categorías dinámicas en lugar de tipos estáticos
- Modifiqué los filtros (FilterBar.vue) para cargar categorías reales del sistema en lugar de valores hardcodeados
- Implementé migración automática de categorías existentes del localStorage al nuevo modelo Category
- Agregué migración de recordatorios para convertir campos type a category automáticamente
- Unifiqué el composable useCategories para usar el modelo Category en lugar de localStorage directo

## ¿Funciona correctamente?
- [X ] Sí, probé la funcionalidad en mi computadora
- [ ] No hay errores en la consola del navegador

## Notas para el revisor
Dropdown de categorías en el modal "Nuevo recordatorio" - ahora muestra categorías reales